### PR TITLE
dummy implementation to add bias to attention to reproduce the precision issue

### DIFF
--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -45,8 +45,6 @@ def mha_forward_kernel(
   # read, compute, and write all in 2d chunks. 1 element ~= 1 CUDA thread index.
   # q tile has shape [block_q, block_d], block_d == head_dim.
   q = pl.load(q_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(None)))
-
-
   # In FlashAttention algorithm 1 there are 2 loops: slow over tiles of kv (size
   # (Bc == block_k here), and fast over blocks of q (size Br == block_q here).
   # Here we only loop over blocks of kv to process entire seq_len, the loop over
@@ -140,7 +138,6 @@ def mha(q, k, v,
   if has_bias:
     bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
   else:
-    # bias_block_spec = pl.BlockSpec(lambda _, __, ___: (), ())
     bias_block_spec = None
 
   return pl.pallas_call(

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1372,6 +1372,9 @@ class FusedAttentionTest(parameterized.TestCase):
           (1, 384, 8, 64, True, True),
           (2, 384, 8, 64, True, True),
           (2, 2048, 32, 64, False, False),
+          (2, 2048, 32, 64, False, True),
+          (4, 1024, 72, 64, False, False),
+          (4, 1024, 72, 64, False, True),
       ]
   ])
   def test_fused_attention_fwd_bias(self, batch_size, seq_len, num_heads, head_dim,


### PR DESCRIPTION
Test consistently fails with larger cases , with precision errors on just a few numbers. It only happens with bias.

>           (2, 2048, 32, 64, False, False),
>           (2, 2048, 32, 64, False, True),
>           (4, 1024, 72, 64, False, False),
>           (4, 1024, 72, 64, False, True),


(tested on A100)